### PR TITLE
updating composer.json to included jsonapi_extras module

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -57,6 +57,7 @@
         "drupal/ckeditor5_icons": "~1.0",
         "drupal/ckeditor5_paste_filter": "^1.0",
         "drupal/consumer_image_styles": "^4.0",
+        "drupal/jsonapi_extras": "^3.26",
         "drupal/core-composer-scaffold": "~10.2.0",
         "drupal/core-project-message": "~10.2.0",
         "drupal/core-recommended": "~10.2.0",


### PR DESCRIPTION
There was a change in a 3rd party repo that requires us to include the jsonapi_extras module into our composer.json file